### PR TITLE
Enforce contact number validation for PH mobile format

### DIFF
--- a/SISTEM/802-GO/app/Http/Controllers/DocumentRequestController.php
+++ b/SISTEM/802-GO/app/Http/Controllers/DocumentRequestController.php
@@ -93,7 +93,7 @@ class DocumentRequestController extends Controller
         $validated = $request->validate([
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
-            'contact_number' => 'required|string|max:15',
+            'contact_number' => ['required', 'regex:/^09[0-9]{9}$/'],
             'document_type' => 'required|string',
             'block_street' => 'required|string|max:255',
             'extra_data' => 'nullable|array',

--- a/SISTEM/802-GO/app/Models/DocumentRequest.php
+++ b/SISTEM/802-GO/app/Models/DocumentRequest.php
@@ -52,7 +52,8 @@ class DocumentRequest extends Model
     // Cast JSON fields automatically
     protected $casts = [
         'date_of_birth' => 'date',
-        'extra_data' => 'array', // Ensure extra_data is stored as an array
+        'extra_data' => 'array',
+        'contact_number' => 'string'
     ];
 
     protected $dates = [

--- a/SISTEM/802-GO/database/migrations/2025_02_24_175341_create_document_requests_table.php
+++ b/SISTEM/802-GO/database/migrations/2025_02_24_175341_create_document_requests_table.php
@@ -6,64 +6,73 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up()
     {
-        Schema::create('document_requests', function (Blueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('user_id')->nullable(); // Link to users table
-            $table->string('document_type'); // e.g., barangay_clearance, business_permit
-            $table->string('reference_number')->unique();
-
-            // Common Fields
-            $table->string('first_name');
-            $table->string('middle_name')->nullable();
-            $table->string('last_name');
-            $table->enum('gender', ['Male', 'Female', 'Other'])->nullable();
-            $table->date('date_of_birth')->nullable();
-            $table->string('civil_status')->nullable();
-            $table->string('contact_number');
-            $table->text('block_street');
-            $table->string('barangay')->default('802');
-            $table->string('district')->default('Sta. Ana');
-            $table->string('city')->default('Manila');
-
-            // Document-Specific Fields (Stored in JSON)
-            $table->json('extra_data')->nullable();
-
-            // Uploadable Files
-            $table->string('valid_id')->nullable();
-            $table->string('proof_of_residency')->nullable();
-            $table->string('recent_photo')->nullable();
-            $table->string('signature')->nullable();
-
-            // Business Permit Specific Fields
-            $table->string('business_name')->nullable();
-            $table->string('business_address')->nullable();
-            $table->string('nature_of_business')->nullable();
-            $table->string('tax_identification_number')->nullable();
-            $table->string('dti_sec_registration')->nullable();
-            $table->string('lease_contract')->nullable();
-            $table->string('business_permit_application')->nullable();
-            $table->string('valid_id_owner')->nullable();
-
-            // Cedula-Specific Fields
-            $table->string('place_of_birth')->nullable();
-            $table->string('citizenship')->nullable();
-            $table->string('occupation')->nullable();
-            $table->decimal('annual_income', 10, 2)->nullable();
-
-            // Other Fields
-            $table->string('purpose_of_request')->nullable();
-            $table->string('purpose_of_cedula')->nullable();
-            $table->string('proof_of_income')->nullable(); // For Indigency
-
-            // Status & Timestamps
-            $table->enum('status', ['pending', 'approved', 'rejected', 'released'])->default('pending');
-            $table->timestamps();
-        });
+        // Modify existing table if it exists
+        if (Schema::hasTable('document_requests')) {
+            Schema::table('document_requests', function (Blueprint $table) {
+                $table->string('contact_number', 15)->change(); // Ensure contact number is a string with max 15 characters
+            });
+        } else {
+            // Create the table if it doesn't exist
+            Schema::create('document_requests', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('document_type');
+                $table->string('reference_number')->unique();
+    
+                // Common Fields
+                $table->string('first_name');
+                $table->string('middle_name')->nullable();
+                $table->string('last_name');
+                $table->enum('gender', ['Male', 'Female', 'Other'])->nullable();
+                $table->date('date_of_birth')->nullable();
+                $table->string('civil_status')->nullable();
+                $table->string('contact_number', 15);
+                $table->text('block_street');
+                $table->string('barangay')->default('802');
+                $table->string('district')->default('Sta. Ana');
+                $table->string('city')->default('Manila');
+    
+                // Document-Specific Fields (Stored in JSON)
+                $table->json('extra_data')->nullable();
+    
+                // Uploadable Files
+                $table->string('valid_id')->nullable();
+                $table->string('proof_of_residency')->nullable();
+                $table->string('recent_photo')->nullable();
+                $table->string('signature')->nullable();
+    
+                // Business Permit Specific Fields
+                $table->string('business_name')->nullable();
+                $table->string('business_address')->nullable();
+                $table->string('nature_of_business')->nullable();
+                $table->string('tax_identification_number')->nullable();
+                $table->string('dti_sec_registration')->nullable();
+                $table->string('lease_contract')->nullable();
+                $table->string('business_permit_application')->nullable();
+                $table->string('valid_id_owner')->nullable();
+    
+                // Cedula-Specific Fields
+                $table->string('place_of_birth')->nullable();
+                $table->string('citizenship')->nullable();
+                $table->string('occupation')->nullable();
+                $table->decimal('annual_income', 10, 2)->nullable();
+    
+                // Other Fields
+                $table->string('purpose_of_request')->nullable();
+                $table->string('purpose_of_cedula')->nullable();
+                $table->string('proof_of_income')->nullable();
+    
+                // Status & Timestamps
+                $table->enum('status', ['pending', 'approved', 'rejected', 'released'])->default('pending');
+                $table->timestamps();
+            });
+        }
     }
 
     public function down()
     {
-        Schema::dropIfExists('document_requests');
+        Schema::table('document_requests', function (Blueprint $table) {
+            $table->string('contact_number')->change(); // Revert to default if necessary
+        });
     }
 };
-

--- a/SISTEM/802-GO/resources/views/document_forms/barangay-clearance.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/barangay-clearance.blade.php
@@ -445,7 +445,7 @@ document.addEventListener("DOMContentLoaded", function() {
             <input id="city" name="city" type="text" value="Manila" class="input-field bg-gray-200" readonly>
 
             <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-            <input id="contact_number" name="contact_number" type="text" class="input-field required" required>
+            <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
             <label class="form-label">Purpose of Request <span class="text-red-500">*</span></label>
 <select id="purpose_of_request" name="purpose_of_request" class="input-field required" required onchange="toggleOtherPurpose()">

--- a/SISTEM/802-GO/resources/views/document_forms/barangay-id.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/barangay-id.blade.php
@@ -457,7 +457,7 @@ document.addEventListener("DOMContentLoaded", function() {
             <input id="city" name="city" type="text" value="Manila" class="input-field bg-gray-200" readonly>
 
             <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-            <input id="contact_number" name="contact_number" type="text" class="input-field required" required>
+            <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
             <label class="form-label">Purpose of Request <span class="text-red-500">*</span></label>
             <select id="purpose_of_request" name="purpose_of_request" class="input-field required" required onchange="toggleOtherPurpose()">

--- a/SISTEM/802-GO/resources/views/document_forms/business-permit.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/business-permit.blade.php
@@ -442,7 +442,7 @@ document.addEventListener("DOMContentLoaded", function() {
             <input id="business_nature" name="business_nature" type="text" class="input-field required" required>
 
             <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-            <input id="contact_number" name="contact_number" type="text" class="input-field required" required>
+            <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
             <label class="form-label">Tax Identification Number (TIN) <span class="text-red-500">*</span></label>
             <input id="tin" name="tin" type="text" class="input-field required" required>

--- a/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
@@ -446,7 +446,7 @@ document.addEventListener("DOMContentLoaded", function() {
         <input id="city" name="city" type="text" value="Manila" class="input-field bg-gray-200" readonly>
 
         <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-        <input id="contact_number" name="contact_number" type="text" class="input-field required" required>
+        <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
         <label class="form-label">Citizenship <span class="text-red-500">*</span></label>
         <input id="citizenship" name="citizenship" type="text" class="input-field required" required>

--- a/SISTEM/802-GO/resources/views/document_forms/certificate-of-residency.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/certificate-of-residency.blade.php
@@ -448,7 +448,7 @@ document.addEventListener("DOMContentLoaded", function() {
         <input id="length_of_stay" type="text" name="length_of_stay" class="input-field required" required>
 
         <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-        <input id="contact_number" type="text" name="contact_number" class="input-field required" required>
+        <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
         <label class="form-label">Purpose of Request <span class="text-red-500">*</span></label>
         <select id="purpose_of_request" name="purpose_of_request" class="input-field required" required onchange="toggleOtherPurpose()">

--- a/SISTEM/802-GO/resources/views/document_forms/indigency-certificate.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/indigency-certificate.blade.php
@@ -444,7 +444,7 @@ document.addEventListener("DOMContentLoaded", function() {
         <input id="city" name="city" type="text" value="Manila" class="input-field bg-gray-200" readonly>
 
         <label class="form-label">Contact Number <span class="text-red-500">*</span></label>
-        <input id="contact_number" name="contact_number" type="text" class="input-field required" required>
+        <input id="contact_number" name="contact_number" type="text" pattern="09[0-9]{9}" maxlength="11" required title="Enter a valid PH mobile number (e.g., 09123456789)" class="input-field required" required>
 
         <label class="form-label">Purpose of Request <span class="text-red-500">*</span></label>
         <select id="purpose_of_request" name="purpose_of_request" class="input-field required" required onchange="toggleOtherPurpose()">


### PR DESCRIPTION
Commit Description:
- Updated validation to ensure contact_number starts with 09 and is exactly 11 digits.
- Applied a regex rule in Laravel validation (/^09[0-9]{9}$/).
- Added a custom error message for invalid phone numbers.
- Updated Blade form input with an HTML pattern to prevent incorrect entries.