### PR TITLE
Cedula Form: Ensure Peso Sign Stays & Allow Comma/Decimal Input

### DIFF
--- a/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
@@ -464,7 +464,10 @@ document.addEventListener("DOMContentLoaded", function() {
         <input id="occupation" name="occupation" type="text" class="input-field required" required>
 
         <label class="form-label">Annual Income <span class="text-red-500">*</span></label>
-        <input id="annual_income" name="annual_income" type="number" class="input-field required" required>
+        <div class="input-group">
+        <input id="annual_income" name="annual_income" type="text" class="input-field required" required placeholder="₱0.00">
+        </div>
+
 
         <label class="form-label">Purpose of Cedula <span class="text-red-500">*</span></label>
         <select id="purpose_of_cedula" name="purpose_of_cedula" class="input-field required" required onchange="toggleOtherPurpose()">
@@ -490,9 +493,27 @@ document.addEventListener("DOMContentLoaded", function() {
         </div>
 
         <button type="submit">Submit</button>
+
+<script>
+document.getElementById('annual_income').addEventListener('input', function (e) {
+    let value = e.target.value;
+
+    // Ensure the value always starts with ₱
+    if (!value.startsWith("₱")) {
+        value = "₱" + value.replace(/₱/g, ""); // Remove extra ₱ if retyped
+    }
+
+    // Remove any invalid characters except numbers, commas, and periods
+    value = value.replace(/[^0-9,\.]/g, '');
+
+    // Ensure peso sign remains at the start
+    e.target.value = "₱" + value;
+});
+</script>
+
+
     </form>
 </div>
-</body>
 
 <!-- Barangay Section -->
 <section class="barangay-section bg-[#11468F] text-white py-8 lg:py-12 px-4 lg:px-6">

--- a/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
+++ b/SISTEM/802-GO/resources/views/document_forms/cedula.blade.php
@@ -510,8 +510,6 @@ document.getElementById('annual_income').addEventListener('input', function (e) 
     e.target.value = "₱" + value;
 });
 </script>
-
-
     </form>
 </div>
 


### PR DESCRIPTION
- Fixed an issue where the peso sign (₱) disappeared while typing.
- Ensured commas (,) and decimal points (.) can be entered freely for formatting.
- Prevents invalid characters (e.g., letters, special symbols).
- Peso sign remains at the start while allowing natural number input.